### PR TITLE
Update Bazel dependencies to newer versions.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,3 +90,11 @@ go_repository(
   importpath = "github.com/google/go-cmp",
   commit = "290a6a23966f9edffe2a0a4a1d8dd065cc0753fd"
 )
+
+# Go Sys. No stable versions available.
+#
+# Last updated: April 8, 2022.
+go_repository(
+  name = "org_golang_x_sys",
+  importpath = "golang.org/x/sys",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,7 @@ gazelle_dependencies()
 go_repository(
   name = "org_golang_google_grpc",
   importpath = "google.golang.org/grpc",
+  sum = "h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=",
   version = "v1.45.0",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,22 +73,24 @@ go_repository(
   version = "v1.28.0",
 )
 
-# Go Cryptography. No stable versions available.
+# Go Cryptography.
 #
-# Last updated: June 4,2021.
+# Last updated: April 8, 2022.
 go_repository(
   name = "org_golang_x_crypto",
   importpath = "golang.org/x/crypto",
-  commit = "c07d793c2f9aacf728fe68cbd7acd73adbd04159"
+  sum = "h1:iU7T1X1J6yxDr0rda54sWGkHgOp5XJrqm79gcNlC2VM=",
+  version = "v0.0.0-20220408190544-5352b0902921",
 )
 
-# Go Sync. No stable versions available.
+# Go Sync.
 #
-# Last updated: June 4,2021.
+# Last updated: April 8, 2022.
 go_repository(
   name = "org_golang_x_sync",
   importpath = "golang.org/x/sync",
-  commit = "036812b2e83c0ddf193dd5a34e034151da389d09"
+  sum = "h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=",
+  version = "v0.0.0-20210220032951-036812b2e83c",
 )
 
 # Go Cmp. No stable versions available.
@@ -100,12 +102,14 @@ go_repository(
   commit = "290a6a23966f9edffe2a0a4a1d8dd065cc0753fd"
 )
 
-# Go Sys. No stable versions available.
+# Go Sys.
 #
 # Last updated: April 8, 2022.
 go_repository(
   name = "org_golang_x_sys",
   importpath = "golang.org/x/sys",
+  sum = "h1:QyVthZKMsyaQwBTJE04jdNN0Pp5Fn9Qga0mrgxyERQM=",
+  version = "v0.0.0-20220406163625-3f8b81556e12",
 )
 
 # Go Net.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,8 +51,7 @@ gazelle_dependencies()
 go_repository(
   name = "org_golang_google_grpc",
   importpath = "google.golang.org/grpc",
-  sum = "h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=",
-  version = "v1.38.0",
+  version = "v1.45.0",
 )
 
 # Go Protobuf.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,10 +57,19 @@ go_repository(
 
 # Go Protobuf.
 #
+#
+go_repository(
+  name = "org_golang_protobuf",
+  importpath = "github.com/golang/protobuf",
+  version = "v1.5.2.",
+)
+
+# Google Protobuf.
+#
 # Last updated: April 8, 2022.
 go_repository(
   name = "org_golang_google_protobuf",
-  importpath = "google.golang/org/protobuf",
+  importpath = "google.golang.org/protobuf",
   version = "v1.28.0",
 )
 
@@ -98,3 +107,24 @@ go_repository(
   name = "org_golang_x_sys",
   importpath = "golang.org/x/sys",
 )
+
+# Go Net.
+#
+# Last updated: April 8, 2022.
+go_repository(
+  name = "org_golang_x_net",
+  importpath = "golang.org/x/net",
+  sum = "h1:EN5+DfgmRMvRUrMGERW2gQl3Vc+Z7ZMnI/xdEpPSf0c=",
+  version = "v0.0.0-20220407224826-aac1ed45d8e3",
+)
+
+# Go Text.
+#
+# Last updated: April 8, 2022.
+go_repository(
+  name = "org_golang_x_text",
+  importpath = "golang.org/x/text",
+  sum = "h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=",
+  version = "v0.3.7",
+)
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,11 +5,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Bazel's proto rules.
 http_archive(
     name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
+    strip_prefix = "rules_proto-4.0.0-3.20.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
     ],
 )
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,11 +57,11 @@ go_repository(
 
 # Go Protobuf.
 #
-# Last updated: September 7, 2021.
+# Last updated: April 8, 2022.
 go_repository(
   name = "org_golang_google_protobuf",
   importpath = "google.golang/org/protobuf",
-  version = "v1.27.1",
+  version = "v1.28.0",
 )
 
 # Go Cryptography. No stable versions available.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,8 @@ workspace(name = "s2a_go")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Bazel's proto rules.
+#
+# Last updated: April 8, 2022.
 http_archive(
     name = "rules_proto",
     sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
@@ -16,12 +18,14 @@ rules_proto_dependencies()
 rules_proto_toolchains()
 
 # Bazel's Go rules.
+#
+# Last updated: April 8, 2022.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
     ],
 )
 
@@ -30,12 +34,14 @@ go_rules_dependencies()
 go_register_toolchains(version = "1.16")
 
 # Bazel Gazelle.
+#
+# Last updated: April 8, 2022.
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
     ],
 )
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")

--- a/s2a.go
+++ b/s2a.go
@@ -42,7 +42,8 @@ const (
 	// defaultTimeout specifies the default server handshake timeout.
 	defaultTimeout = 30.0 * time.Second
 )
-
+// FIGURING OUT WHAT TO DO
+/
 // s2aTransportCreds are the transport credentials required for establishing
 // a secure connection using the S2A. They implement the
 // credentials.TransportCredentials interface.

--- a/s2a.go
+++ b/s2a.go
@@ -42,8 +42,7 @@ const (
 	// defaultTimeout specifies the default server handshake timeout.
 	defaultTimeout = 30.0 * time.Second
 )
-// FIGURING OUT WHAT TO DO
-/
+
 // s2aTransportCreds are the transport credentials required for establishing
 // a secure connection using the S2A. They implement the
 // credentials.TransportCredentials interface.

--- a/tools/internal_ci/run_tests.sh
+++ b/tools/internal_ci/run_tests.sh
@@ -32,7 +32,7 @@ run_tests() {
 
 main() {
   if [[ -n "${KOKORO_ROOT}" ]]; then
-    use_bazel.sh "4.1.0"
+    use_bazel.sh "4.2.1"
   fi
   run_tests
 }


### PR DESCRIPTION
Update Bazel dependencies, which also fixes the broken Kokoro tests.