### PR TITLE
Update go.mod to 1.16 to support go:embed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/s2a-go
 
-go 1.14
+go 1.16
 
 require (
 	github.com/golang/protobuf v1.5.2


### PR DESCRIPTION
While working on TLS Configuration Store library implementation, I ran into an error : 
"go:embed requires go1.16 or later (-lang was set to go1.14; check go.mod)".  Update go.mod to support go:embed.