### PR TITLE
Remove InsecureSkipVerify from server TLS config

### DIFF
--- a/internal/v2/tls_config_store/tls_config_store.go
+++ b/internal/v2/tls_config_store/tls_config_store.go
@@ -178,7 +178,6 @@ func GetTlsConfigurationForServer(cstream s2av2pb.S2AService_SetUpSessionClient)
 		ClientCAs: clientCApool,
 		// TODO(rmehta19): Remove "+ 2" when proto file enum change is merged.
 		ClientAuth: tls.ClientAuthType(tlsConfig.RequestClientCertificate) + 2,
-		InsecureSkipVerify: true,
 		MinVersion: minVersion,
 		MaxVersion: maxVersion,
 	}, nil

--- a/internal/v2/tls_config_store/tls_config_store_test.go
+++ b/internal/v2/tls_config_store/tls_config_store_test.go
@@ -183,7 +183,6 @@ func TestTLSConfigStoreServer(t *testing.T) {
 		description		    string
 		Certificates                []tls.Certificate
 		ClientAuth		    tls.ClientAuthType
-		InsecureSkipVerify          bool
 		MinVersion	            uint16
 		MaxVersion		    uint16
 	}{
@@ -191,7 +190,6 @@ func TestTLSConfigStoreServer(t *testing.T) {
 			description: "static",
 			Certificates: []tls.Certificate{cert},
 			ClientAuth: tls.RequireAndVerifyClientCert,
-			InsecureSkipVerify: true,
 			MinVersion: tls.VersionTLS13,
 			MaxVersion: tls.VersionTLS13,
 		},
@@ -206,9 +204,6 @@ func TestTLSConfigStoreServer(t *testing.T) {
 			}
 			if got, want := config.ClientAuth, tc.ClientAuth; got != want {
 				t.Errorf("config.ClientAuth = %v, want %v", got, want)
-			}
-			if got, want := config.InsecureSkipVerify, tc.InsecureSkipVerify; got != want {
-				t.Errorf("config.InsecureSkipVerify = %v, want %v", got, want)
 			}
 			if got, want := config.MinVersion, tc.MinVersion; got != want {
 				t.Errorf("config.MinVersion = %v, want %v", got, want)


### PR DESCRIPTION
Remove InsecureSkipVerify from server TLS config.

As noted in the [documentation for InsecureSkipVerify](https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/crypto/tls/common.go;l=647), this field is only used if set in the client TLS config. It controls whether a client verifies the server's certificate chain and host name.

Brought up Go echo client server to verify this change does not impact anything:

bazel run fakes2av2_server
![image](https://user-images.githubusercontent.com/55350838/174902469-d591bc73-5dbe-4183-8aa0-7e377b004ba6.png)

bazel run server
![image](https://user-images.githubusercontent.com/55350838/174902498-4de766b5-7edd-4b26-b584-21321d9b2a62.png)

bazel run client
![image](https://user-images.githubusercontent.com/55350838/174902524-7a788b96-a93d-421b-b01c-19f64f34eca6.png)
