### PR TITLE
Call the token manager for authentication mechanism

### DIFF
--- a/internal/v2/BUILD
+++ b/internal/v2/BUILD
@@ -13,7 +13,9 @@ go_library(
   importpath = "github.com/google/s2a-go/internal/v2",
   deps = [
     "//internal/handshaker/service",
+    "//internal/proto/common_go_proto:common_go_proto",
     "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
+    "//internal/tokenmanager",
     "//internal/v2/tls_config_store",
     "@org_golang_google_grpc//credentials:go_default_library",
     "@org_golang_google_grpc//:go_default_library",

--- a/internal/v2/cert_verifier/BUILD
+++ b/internal/v2/cert_verifier/BUILD
@@ -29,8 +29,8 @@ go_test(
 
   ],
   deps = [
-    "//internal/v2/fakes2av2",
     "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
+    "//internal/v2/fakes2av2",
     "@org_golang_google_grpc//:go_default_library",
     "@org_golang_google_grpc//credentials/insecure:go_default_library",
   ],

--- a/internal/v2/cert_verifier/cert_verifier.go
+++ b/internal/v2/cert_verifier/cert_verifier.go
@@ -15,12 +15,6 @@ func VerifyClientCertificateChain(cstream s2av2pb.S2AService_SetUpSessionClient)
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		// Offload verification to S2Av2.
 		if err := cstream.Send(&s2av2pb.SessionReq {
-			AuthenticationMechanisms: []*s2av2pb.AuthenticationMechanism {
-				{
-					// TODO(rmehta19): Populate Authentication Mechanism using tokenmanager.
-					MechanismOneof: &s2av2pb.AuthenticationMechanism_Token{"token"},
-				},
-			},
 			ReqOneof: &s2av2pb.SessionReq_ValidatePeerCertificateChainReq {
 				&s2av2pb.ValidatePeerCertificateChainReq {
 					Mode: s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE,
@@ -56,12 +50,6 @@ func VerifyServerCertificateChain(hostname string, cstream s2av2pb.S2AService_Se
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		// Offload verification to S2Av2.
 		if err := cstream.Send(&s2av2pb.SessionReq {
-			AuthenticationMechanisms: []*s2av2pb.AuthenticationMechanism {
-				{
-					// TODO(rmehta19): Populate Authentication Mechanism using tokenmanager.
-					MechanismOneof: &s2av2pb.AuthenticationMechanism_Token{"token"},
-				},
-			},
 			ReqOneof: &s2av2pb.SessionReq_ValidatePeerCertificateChainReq {
 				&s2av2pb.ValidatePeerCertificateChainReq {
 					Mode: s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE,

--- a/internal/v2/cert_verifier/cert_verifier_test.go
+++ b/internal/v2/cert_verifier/cert_verifier_test.go
@@ -62,7 +62,7 @@ func TestVerifyClientCertChain(t *testing.T) {
 	stop, address, err := startFakeS2Av2Server(&wg)
 	wg.Wait()
 	if err != nil {
-		log.Fatalf("error starting fake S2Av2 Server: %v", err)
+		t.Fatalf("error starting fake S2Av2 Server: %v", err)
 	}
 
 	for _, tc := range []struct {
@@ -100,7 +100,7 @@ func TestVerifyClientCertChain(t *testing.T) {
 			}
 			conn, err := grpc.Dial(address, opts...)
 			if err != nil {
-				log.Fatalf("Client: failed to connect: %v", err)
+				t.Fatalf("Client: failed to connect: %v", err)
 			}
 			defer conn.Close()
 			c := s2av2pb.NewS2AServiceClient(conn)
@@ -112,7 +112,7 @@ func TestVerifyClientCertChain(t *testing.T) {
 			callOpts := []grpc.CallOption{}
 			cstream, err := c.SetUpSession(ctx, callOpts...)
 			if err != nil  {
-				log.Fatalf("Client: failed to setup bidirectional streaming RPC session: %v", err)
+				t.Fatalf("Client: failed to setup bidirectional streaming RPC session: %v", err)
 			}
 			log.Printf("Client: set up bidirectional streaming RPC session.")
 
@@ -143,7 +143,7 @@ func TestVerifyServerCertChain(t *testing.T) {
 	stop, address, err := startFakeS2Av2Server(&wg)
 	wg.Wait()
 	if err != nil {
-		log.Fatalf("error starting fake S2Av2 Server: %v", err)
+		t.Fatalf("error starting fake S2Av2 Server: %v", err)
 	}
 
 	for _, tc := range []struct {
@@ -180,7 +180,7 @@ func TestVerifyServerCertChain(t *testing.T) {
 			}
 			conn, err := grpc.Dial(address, opts...)
 			if err != nil {
-				log.Fatalf("Client: failed to connect: %v", err)
+				t.Fatalf("Client: failed to connect: %v", err)
 			}
 			defer conn.Close()
 			c := s2av2pb.NewS2AServiceClient(conn)
@@ -192,7 +192,7 @@ func TestVerifyServerCertChain(t *testing.T) {
 			callOpts := []grpc.CallOption{}
 			cstream, err := c.SetUpSession(ctx, callOpts...)
 			if err != nil  {
-				log.Fatalf("Client: failed to setup bidirectional streaming RPC session: %v", err)
+				t.Fatalf("Client: failed to setup bidirectional streaming RPC session: %v", err)
 			}
 			log.Printf("Client: set up bidirectional streaming RPC session.")
 

--- a/internal/v2/remote_signer/BUILD
+++ b/internal/v2/remote_signer/BUILD
@@ -24,8 +24,8 @@ go_test(
     "example_cert_key/key.pem",
   ],
   deps = [
+    "//internal/v2/fakes2av2",
     "@org_golang_google_grpc//credentials/insecure:go_default_library",
     "@org_golang_google_grpc//:go_default_library",
-    "//internal/v2/fakes2av2",
   ],
 )

--- a/internal/v2/remote_signer/remote_signer.go
+++ b/internal/v2/remote_signer/remote_signer.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
+
 	s2av2pb "github.com/google/s2a-go/internal/proto/v2/s2a_go_proto"
 	commonpbv1 "github.com/google/s2a-go/internal/proto/common_go_proto"
 )
@@ -32,12 +33,6 @@ func (s *remoteSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpt
 	// Send request to S2Av2 to perform private key operation.
 	if err := s.cstream.Send(&s2av2pb.SessionReq {
 		LocalIdentity: s.localIdentity,
-		AuthenticationMechanisms: []*s2av2pb.AuthenticationMechanism {
-			{
-				// TODO(rmehta19): Populate Authentication Mechanism using tokenmanager.
-				MechanismOneof: &s2av2pb.AuthenticationMechanism_Token{"token"},
-			},
-		},
 		ReqOneof: &s2av2pb.SessionReq_OffloadPrivateKeyOperationReq {
 			&s2av2pb.OffloadPrivateKeyOperationReq {
 				Operation: s2av2pb.OffloadPrivateKeyOperationReq_SIGN,

--- a/internal/v2/remote_signer/remote_signer_test.go
+++ b/internal/v2/remote_signer/remote_signer_test.go
@@ -60,7 +60,7 @@ func TestSign(t *testing.T) {
 	stop, address, err := startFakeS2Av2Server(&wg)
 	wg.Wait()
 	if err != nil {
-		log.Fatalf("error starting fake S2Av2 Server: %v", err)
+		t.Fatalf("error starting fake S2Av2 Server: %v", err)
 	}
 
 	// Create stream to S2Av2.
@@ -71,7 +71,7 @@ func TestSign(t *testing.T) {
 	}
 	conn, err := grpc.Dial(address, opts...)
 	if err != nil {
-		log.Fatalf("Client: failed to connect: %v", err)
+		t.Fatalf("Client: failed to connect: %v", err)
 	}
 	defer conn.Close()
 	c := s2av2pb.NewS2AServiceClient(conn)
@@ -83,7 +83,7 @@ func TestSign(t *testing.T) {
 	callOpts := []grpc.CallOption{}
 	cstream, err := c.SetUpSession(ctx, callOpts...)
 	if err != nil  {
-		log.Fatalf("Client: failed to setup bidirectional streaming RPC session: %v", err)
+		t.Fatalf("Client: failed to setup bidirectional streaming RPC session: %v", err)
 	}
 	log.Printf("Client: set up bidirectional streaming RPC session.")
 
@@ -91,11 +91,11 @@ func TestSign(t *testing.T) {
 	// Setup data for testing Sign
 	clientTlsCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
 	if err != nil {
-		log.Fatalf("tls.X509KeyPair failed: %v", err)
+		t.Fatalf("tls.X509KeyPair failed: %v", err)
 	}
 	clientx509Cert, err := x509.ParseCertificate(clientCertDER)
 	if err != nil {
-		log.Fatalf("failed to parse cert: %v", err)
+		t.Fatalf("failed to parse cert: %v", err)
 	}
 	testInBytes := []byte("Test data.")
 

--- a/internal/v2/s2av2_e2e_test.go
+++ b/internal/v2/s2av2_e2e_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"os"
 	"time"
 	"context"
 	"fmt"
@@ -17,8 +18,10 @@ import (
 )
 
 const (
+	accessTokenEnvVariable = "S2A_ACCESS_TOKEN"
+	testAccessToken        = "test_access_token"
 	defaultE2ETimeout      = time.Second*5
-	clientMessage       = "echo"
+	clientMessage          = "echo"
 )
 
 // server implements the helloworld.GreeterServer.
@@ -126,7 +129,7 @@ func runClient(ctx context.Context, t *testing.T, clientS2AAddress, serverAddr s
 }
 
 func TestEndToEndUsingFakeS2AOverTCP(t *testing.T) {
-	// TODO(rmehta19): Set S2A_ACCESS_TOKEN env variable once #46 merges.
+	os.Setenv(accessTokenEnvVariable, testAccessToken)
 	// Start the fake S2As for the client and server.
 	serverS2AAddr := startFakeS2A(t)
 	grpclog.Infof("fake handshaker for server running at address: %v", serverS2AAddr)
@@ -144,7 +147,7 @@ func TestEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 }
 
 func TestEndToEndUsingFakeS2AOnUDS(t *testing.T) {
-	// TODO(rmehta19): Set S2A_ACCESS_TOKEN env variable once #46 merges.
+	os.Setenv(accessTokenEnvVariable, testAccessToken)
 	// Start fake S2As for use by the client and server.
 	serverS2AAddr := startFakeS2AOnUDS(t)
 	grpclog.Infof("fake S2A for server listening on UDS at address: %v", serverS2AAddr)

--- a/internal/v2/s2av2_test.go
+++ b/internal/v2/s2av2_test.go
@@ -1,9 +1,11 @@
 package v2
 
 import (
+	"os"
 	"testing"
 	"context"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/s2a-go/internal/tokenmanager"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -16,6 +18,7 @@ var (
 // example/server, example/client and internal/v2/fakes2av2_server.
 
 func TestNewClientCreds(t *testing.T) {
+	os.Setenv("S2A_ACCESS_TOKEN", "TestNewClientCreds_s2a_access_token")
 	for _, tc := range []struct {
 		description string
 	}{
@@ -40,6 +43,7 @@ func TestNewClientCreds(t *testing.T) {
 }
 
 func TestNewServerCreds(t *testing.T) {
+	os.Setenv("S2A_ACCESS_TOKEN", "TestNewServerCreds_s2a_access_token")
 	for _, tc := range []struct {
 		description string
 	}{
@@ -78,6 +82,7 @@ func TestServerHandshakeFail(t *testing.T) {
 }
 
 func TestInfo(t *testing.T) {
+	os.Setenv("S2A_ACCESS_TOKEN", "TestInfo_s2a_access_token")
 	c, err := NewClientCreds(fakes2av2Address)
 	if err != nil {
 		t.Fatalf("NewClientCreds() failed: %v", err)
@@ -89,6 +94,7 @@ func TestInfo(t *testing.T) {
 }
 
 func TestCloneClient(t *testing.T) {
+	os.Setenv("S2A_ACCESS_TOKEN", "TestCloneClient_s2a_access_token")
 	c, err := NewClientCreds(fakes2av2Address)
 	if err != nil {
 		t.Fatalf("NewClientCreds() failed: %v", err)
@@ -102,17 +108,46 @@ func TestCloneClient(t *testing.T) {
 	if !ok {
 		t.Fatal("the created clone creds is not of type s2aTransportCreds")
 	}
-	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{})), true; got != want {
-		t.Errorf("cmp.Equal(%v, %v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
+	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{}), cmp.Comparer(func(x, y tokenmanager.AccessTokenManager) bool {
+		xToken, err := x.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		yToken, err := y.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		if xToken == yToken {
+			return true
+		} else {
+			return false
+		}
+	})), true; got != want {
+		t.Errorf("cmp.Equal(%+v, %+v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
 	}
 	// Change the values and verify the creds were deep copied.
 	s2av2CloneCreds.info.SecurityProtocol = "s2a"
-	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{})), false; got != want {
-		t.Errorf("cmp.Equal(%v, %v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
+	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{}), cmp.Comparer(func(x, y tokenmanager.AccessTokenManager) bool {
+		xToken, err := x.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		yToken, err := y.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		if xToken == yToken {
+			return true
+		} else {
+			return false
+		}
+	})), false; got != want {
+		t.Errorf("cmp.Equal(%+v, %+v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
 	}
 }
 
 func TestCloneServer(t *testing.T) {
+	os.Setenv("S2A_ACCESS_TOKEN", "TestCloneServer_s2a_access_token")
 	c, err := NewServerCreds(fakes2av2Address)
 	if err != nil {
 		t.Fatalf("NewServerCreds() failed: %v", err)
@@ -126,18 +161,47 @@ func TestCloneServer(t *testing.T) {
 	if !ok {
 		t.Fatal("the created clone creds is not of type s2aTransportCreds")
 	}
-	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{})), true; got != want {
-		t.Errorf("cmp.Equal(%v, %v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
+	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{}), cmp.Comparer(func(x, y tokenmanager.AccessTokenManager) bool {
+		xToken, err := x.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		yToken, err := y.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		if xToken == yToken {
+			return true
+		} else {
+			return false
+		}
+	})), true; got != want {
+		t.Errorf("cmp.Equal(%+v, %+v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
 	}
 	// Change the values and verify the creds were deep copied.
 	s2av2CloneCreds.info.SecurityProtocol = "s2a"
-	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{})), false; got != want {
-		t.Errorf("cmp.Equal(%v, %v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
+	if got, want := cmp.Equal(s2av2Creds, s2av2CloneCreds, protocmp.Transform(), cmp.AllowUnexported(s2av2TransportCreds{}), cmp.Comparer(func(x, y tokenmanager.AccessTokenManager) bool {
+		xToken, err := x.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		yToken, err := y.DefaultToken()
+		if err != nil {
+			t.Errorf("failed to compare cloned creds: %v", err)
+		}
+		if xToken == yToken {
+			return true
+		} else {
+			return false
+		}
+	})), false; got != want {
+		t.Errorf("cmp.Equal(%+v, %+v) = %v, want %v", s2av2Creds, s2av2CloneCreds, got, want)
 	}
 }
 
 func TestOverrideServerName(t *testing.T) {
 	// Setup test.
+	os.Setenv("S2A_ACCESS_TOKEN", "TestOverrideServerName_s2a_access_token")
 	c, err := NewClientCreds(fakes2av2Address)
 	s2av2Creds, ok := c.(*s2av2TransportCreds)
 	if !ok {

--- a/internal/v2/tls_config_store/BUILD
+++ b/internal/v2/tls_config_store/BUILD
@@ -17,12 +17,14 @@ go_library(
     "example_cert_key/server_key.pem",
   ],
   deps = [
-    "//internal/v2/cert_verifier",
-    "//internal/v2/remote_signer",
     "//internal/proto/common_go_proto:common_go_proto",
     "//internal/proto/v2/common_go_proto:common_go_proto",
     "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
+    "//internal/tokenmanager",
+    "//internal/v2/cert_verifier",
+    "//internal/v2/remote_signer",
     "@org_golang_google_grpc//codes:go_default_library",
+    "@org_golang_google_grpc//grpclog:go_default_library",
   ],
 )
 
@@ -37,9 +39,14 @@ go_test(
     "example_cert_key/server_key.pem",
   ],
   deps = [
-    "//internal/v2/fakes2av2",
+    "//internal/proto/common_go_proto:common_go_proto",
     "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
+    "//internal/tokenmanager",
+    "//internal/v2/fakes2av2",
+    "@com_github_google_go_cmp//cmp:go_default_library",
+    "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
     "@org_golang_google_grpc//:go_default_library",
     "@org_golang_google_grpc//credentials/insecure:go_default_library",
+    "@org_golang_google_protobuf//testing/protocmp:go_default_library",
   ],
 )


### PR DESCRIPTION
Modify s2av2 to call tokenmanager library to establish a default token that can be attached to all RPCs made to s2av2. 

Note that in actual s2av2 implementation the only time the token is read is when the first SessionReq is made, all following SessionReq RPC authentication mechanisms are not read.