### PR TITLE
Add GetConfigForClient field to Server TLS Config

### DIFF
--- a/internal/v2/remote_signer/remote_signer.go
+++ b/internal/v2/remote_signer/remote_signer.go
@@ -32,6 +32,7 @@ func (s *remoteSigner) Public() crypto.PublicKey {
 }
 
 func (s *remoteSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	// TODO(rmehta19): remove LocalIdentity from SessionReq.
 	// Send request to S2Av2 to perform private key operation.
 	if err := s.cstream.Send(&s2av2pb.SessionReq {
 		LocalIdentity: s.localIdentity,


### PR DESCRIPTION
Add GetConfigForClient field to Server TLS Config. 

This allows the Server to use SNI from ClientHello to return a config with the certificate that the client expects, and establish a secure connection. 

Added corresponding unit tests to TLS Config store test suite. While adding these tests, cleaned up existing tests to ensure stream creation happens during each unit tests(in future if we add failing tests, stream needs to be recreated; it cannot be reused by failing / passing tests)