### PR TITLE
Handle SessionResp Status field in Cert Verifier

### DIFF
--- a/internal/v2/cert_verifier/BUILD
+++ b/internal/v2/cert_verifier/BUILD
@@ -11,6 +11,7 @@ go_library(
   importpath = "github.com/google/s2a-go/internal/v2/cert_verifier",
   deps = [
     "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
+    "@org_golang_google_grpc//codes:go_default_library",
   ],
 )
 

--- a/internal/v2/cert_verifier/cert_verifier.go
+++ b/internal/v2/cert_verifier/cert_verifier.go
@@ -2,7 +2,9 @@
 package certverifier
 
 import (
+	"fmt"
 	"crypto/x509"
+	"google.golang.org/grpc/codes"
 
 	s2av2pb "github.com/google/s2a-go/internal/proto/v2/s2a_go_proto"
 )
@@ -34,12 +36,16 @@ func VerifyClientCertificateChain(cstream s2av2pb.S2AService_SetUpSessionClient)
 		}
 
 		// Get the response from S2Av2.
-		_, err := cstream.Recv()
+		resp, err := cstream.Recv()
 		if err != nil {
 			return err
 		}
 
-		// TODO(rmehta19): Parse response.
+		// Parse the response
+		if resp.GetStatus().Code != uint32(codes.OK) {
+			return fmt.Errorf("Failed to offload client cert verification to S2A: %d, %v", resp.GetStatus().Code, resp.GetStatus().Details)
+
+		}
 		return nil
 	}
 }
@@ -72,12 +78,15 @@ func VerifyServerCertificateChain(hostname string, cstream s2av2pb.S2AService_Se
 		}
 
 		// Get the response from S2Av2.
-		_, err := cstream.Recv()
+		resp, err := cstream.Recv()
 		if err != nil {
 			return err
 		}
 
-		// TODO(rmehta19): Parse response.
+		// Parse the response
+		if resp.GetStatus().Code != uint32(codes.OK) {
+			return fmt.Errorf("Failed to offload client cert verification to S2A: %d, %v", resp.GetStatus().Code, resp.GetStatus().Details)
+		}
 		return nil
 	}
 }

--- a/internal/v2/cert_verifier/cert_verifier_test.go
+++ b/internal/v2/cert_verifier/cert_verifier_test.go
@@ -73,7 +73,7 @@ func TestVerifyClientCertChain(t *testing.T) {
 		{
 			description: "empty chain",
 			rawCerts: nil,
-			expectedErr: errors.New("rpc error: code = Unknown desc = Client Peer Verification failed: client cert chain is empty."),
+			expectedErr: errors.New("Failed to offload client cert verification to S2A: 3, Client Peer Verification failed: client cert chain is empty."),
 		},
 		{
 			description: "chain of length 1",
@@ -88,7 +88,7 @@ func TestVerifyClientCertChain(t *testing.T) {
 		{
 			description: "chain of length 2 error: missing intermediate",
 			rawCerts: [][]byte{clientLeafDERCert, clientRootDERCert,},
-			expectedErr: errors.New("rpc error: code = Unknown desc = x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"s2a_test_cert\")"),
+			expectedErr: errors.New("Failed to offload client cert verification to S2A: 3, Client Peer Verification failed: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"s2a_test_cert\")"),
 		},
 	}{
 		t.Run(tc.description, func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestVerifyServerCertChain(t *testing.T) {
 			description: "empty chain",
 			hostname: "host",
 			rawCerts: nil,
-			expectedErr: errors.New("rpc error: code = Unknown desc = Server Peer Verification failed: server cert chain is empty."),
+			expectedErr: errors.New("Failed to offload client cert verification to S2A: 3, Server Peer Verification failed: server cert chain is empty."),
 		},
 		{
 			description: "chain of length 1",

--- a/internal/v2/fakes2av2/fakes2av2.go
+++ b/internal/v2/fakes2av2/fakes2av2.go
@@ -234,8 +234,8 @@ func buildValidatePeerCertificateChainSessionResp(StatusCode uint32, StatusDetai
 func verifyClientPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.SessionResp, error) {
 	derCertChain := req.GetClientPeer().CertificateChain
 	if len(derCertChain) == 0 {
-		err := errors.New("Client Peer Verification failed: client cert chain is empty.")
-		return buildValidatePeerCertificateChainSessionResp(3, err.Error(), s2av2pb.ValidatePeerCertificateChainResp_FAILURE, err.Error(), &s2av2ctx.S2AContext{}), err
+		s := "Client Peer Verification failed: client cert chain is empty."
+		return buildValidatePeerCertificateChainSessionResp(3, s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
 	}
 
 	// Obtain the set of root certificates.
@@ -268,7 +268,7 @@ func verifyClientPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.Se
 	}
 	if _, err := x509LeafCert.Verify(opts); err != nil {
 		s := fmt.Sprintf("Client Peer Verification failed: %v", err)
-		return buildValidatePeerCertificateChainSessionResp(3, s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), err
+		return buildValidatePeerCertificateChainSessionResp(3, s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
 	}
 	return buildValidatePeerCertificateChainSessionResp(0, "", s2av2pb.ValidatePeerCertificateChainResp_SUCCESS, "Client Peer Verification succeeded", &s2av2ctx.S2AContext{}), nil
 }
@@ -276,8 +276,8 @@ func verifyClientPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.Se
 func verifyServerPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.SessionResp, error) {
 	derCertChain := req.GetServerPeer().CertificateChain
 	if len(derCertChain) == 0 {
-		err := errors.New("Server Peer Verification failed: server cert chain is empty.")
-		return buildValidatePeerCertificateChainSessionResp(3, err.Error(), s2av2pb.ValidatePeerCertificateChainResp_FAILURE, err.Error(), &s2av2ctx.S2AContext{}), err
+		s := "Server Peer Verification failed: server cert chain is empty."
+		return buildValidatePeerCertificateChainSessionResp(3, s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
 	}
 
 	// Obtain the set of root certificates.
@@ -311,7 +311,7 @@ func verifyServerPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.Se
 	}
 	if _, err := x509LeafCert.Verify(opts); err != nil {
 		s := fmt.Sprintf("Server Peer Verification failed: %v", err)
-		return buildValidatePeerCertificateChainSessionResp(3, s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), err
+		return buildValidatePeerCertificateChainSessionResp(3, s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
 	}
 
 	return buildValidatePeerCertificateChainSessionResp(0, "", s2av2pb.ValidatePeerCertificateChainResp_SUCCESS, "Server Peer Verification succeeded",&s2av2ctx.S2AContext{}), nil

--- a/internal/v2/fakes2av2/fakes2av2_test.go
+++ b/internal/v2/fakes2av2/fakes2av2_test.go
@@ -12,8 +12,8 @@ import (
 	"crypto/tls"
 	"context"
 	"testing"
-	"google.golang.org/grpc"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -220,6 +220,40 @@ func TestSetUpSession(t *testing.T) {
 					&s2av2pb.ValidatePeerCertificateChainResp {
 						ValidationResult: s2av2pb.ValidatePeerCertificateChainResp_SUCCESS,
 						ValidationDetails: "Client Peer Verification succeeded",
+						Context: &s2av2ctx.S2AContext{},
+					},
+				},
+			},
+		},
+		{
+			description: "Client Peer Verification -- failure",
+			request: &s2av2pb.SessionReq {
+				AuthenticationMechanisms: []*s2av2pb.AuthenticationMechanism {
+					{
+						// TODO(rmehta19): Populate Authentication Mechanism using tokenmanager.
+						MechanismOneof: &s2av2pb.AuthenticationMechanism_Token{"token"},
+					},
+				},
+				ReqOneof: &s2av2pb.SessionReq_ValidatePeerCertificateChainReq {
+					&s2av2pb.ValidatePeerCertificateChainReq {
+						Mode: s2av2pb.ValidatePeerCertificateChainReq_SPIFFE,
+						PeerOneof: &s2av2pb.ValidatePeerCertificateChainReq_ClientPeer_ {
+							&s2av2pb.ValidatePeerCertificateChainReq_ClientPeer {
+								CertificateChain: [][]byte{},
+							},
+						},
+					},
+				},
+			},
+			expectedResponse: &s2av2pb.SessionResp {
+				Status: &s2av2pb.Status {
+					Code: uint32(codes.InvalidArgument),
+					Details: "Client Peer Verification failed: client cert chain is empty.",
+				},
+				RespOneof: &s2av2pb.SessionResp_ValidatePeerCertificateChainResp {
+					&s2av2pb.ValidatePeerCertificateChainResp {
+						ValidationResult: s2av2pb.ValidatePeerCertificateChainResp_FAILURE,
+						ValidationDetails: "Client Peer Verification failed: client cert chain is empty.",
 						Context: &s2av2ctx.S2AContext{},
 					},
 				},


### PR DESCRIPTION
Modify fake s2av2 to return InvalidArgument status when error is triggered by bad data given by s2av2 client in SessionReq. In this case, RPC does not return an error, rather it builds a SessionResp indicating bad data given by client in SessionReq. Added unit test to test this new branch of code. 

Handle SessionResp Status field in Cert Verifier lib.