### PR TITLE
Handle SessionResp Status field in Remote Signer

### DIFF
--- a/internal/v2/fakes2av2/BUILD
+++ b/internal/v2/fakes2av2/BUILD
@@ -19,8 +19,8 @@ go_library(
   ],
   deps = [
     "//internal/proto/v2/common_go_proto:common_go_proto",
-    "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
     "//internal/proto/v2/s2a_context_go_proto:s2a_context_go_proto",
+    "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
     "@org_golang_google_grpc//codes:go_default_library",
   ],
 )
@@ -32,8 +32,8 @@ go_test(
   deps = [
     "//internal/proto/common_go_proto:common_go_proto",
     "//internal/proto/v2/common_go_proto:common_go_proto",
-    "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
     "//internal/proto/v2/s2a_context_go_proto:s2a_context_go_proto",
+    "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
     "@org_golang_google_protobuf//testing/protocmp:go_default_library",
     "@com_github_google_go_cmp//cmp:go_default_library",
     "@org_golang_google_grpc//codes:go_default_library",

--- a/internal/v2/fakes2av2/fakes2av2.go
+++ b/internal/v2/fakes2av2/fakes2av2.go
@@ -98,7 +98,12 @@ func offloadPrivateKeyOperation(req *s2av2pb.OffloadPrivateKeyOperationReq, host
 			}
 		default:
 			s := fmt.Sprintf("Invalid hostname tied to SessionReq: %s", hostname)
-			return nil, errors.New(s)
+			return &s2av2pb.SessionResp {
+				Status: &s2av2pb.Status {
+					Code: 3,
+					Details: s,
+				},
+			},nil
 		}
 		var signedBytes []byte
 		if req.GetSignatureAlgorithm() == s2av2pb.SignatureAlgorithm_S2A_SSL_SIGN_RSA_PKCS1_SHA256 {

--- a/internal/v2/fakes2av2/fakes2av2_test.go
+++ b/internal/v2/fakes2av2/fakes2av2_test.go
@@ -360,7 +360,7 @@ func TestSetUpSession(t *testing.T) {
 			},
 		},
 		{
-			description: "client side private key operation -- error",
+			description: "client side private key operation -- invalid signature algorithm",
 			request: &s2av2pb.SessionReq {
 				LocalIdentity: &commonpbv1.Identity {
 					IdentityOneof: &commonpbv1.Identity_Hostname {
@@ -385,6 +385,35 @@ func TestSetUpSession(t *testing.T) {
 				Status: &s2av2pb.Status {
 					Code: 3,
 					Details: fmt.Sprintf("invalid signature algorithm: %v", s2av2pb.SignatureAlgorithm_S2A_SSL_SIGN_UNSPECIFIED),
+				},
+			},
+		},
+		{
+			description: "client side private key operation -- invalid hostname",
+			request: &s2av2pb.SessionReq {
+				LocalIdentity: &commonpbv1.Identity {
+					IdentityOneof: &commonpbv1.Identity_Hostname {
+						Hostname: "invalid_hostname",
+					},
+				},
+				AuthenticationMechanisms: []*s2av2pb.AuthenticationMechanism {
+					{
+						// TODO(rmehta19): Populate Authentication Mechanism using tokenmanager.
+						MechanismOneof: &s2av2pb.AuthenticationMechanism_Token{"token"},
+					},
+				},
+				ReqOneof: &s2av2pb.SessionReq_OffloadPrivateKeyOperationReq {
+					&s2av2pb.OffloadPrivateKeyOperationReq {
+						Operation: s2av2pb.OffloadPrivateKeyOperationReq_SIGN,
+						SignatureAlgorithm: s2av2pb.SignatureAlgorithm_S2A_SSL_SIGN_UNSPECIFIED,
+						InBytes: []byte(hsha256[:]),
+					},
+				},
+			},
+			expectedResponse: &s2av2pb.SessionResp {
+				Status: &s2av2pb.Status {
+					Code: 3,
+					Details: fmt.Sprintf("Invalid hostname tied to SessionReq: invalid_hostname"),
 				},
 			},
 		},

--- a/internal/v2/remote_signer/BUILD
+++ b/internal/v2/remote_signer/BUILD
@@ -9,6 +9,7 @@ go_library(
   srcs = ["remote_signer.go"],
   importpath = "github.com/google/s2a-go/internal/v2/remote_signer",
   deps = [
+    "@org_golang_google_grpc//codes:go_default_library",
     "//internal/proto/v2/s2a_go_proto:s2a_go_proto",
     "//internal/proto/common_go_proto:common_go_proto",
   ],


### PR DESCRIPTION
Modify fake s2av2 to return InvalidArgument status when error is triggered by bad data given by s2av2 client in SessionReq. In this case, RPC does not return an error, rather it builds a SessionResp indicating bad data given by client in SessionReq. Added unit test to test this new branch of code.

Handle SessionResp Status field in Remote Signer lib.