### PR TITLE
Check ValidationResult

### DIFF
--- a/internal/v2/cert_verifier/cert_verifier.go
+++ b/internal/v2/cert_verifier/cert_verifier.go
@@ -65,6 +65,11 @@ func VerifyClientCertificateChain(verificationMode s2av2pb.ValidatePeerCertifica
 			return fmt.Errorf("failed to offload client cert verification to S2A: %d, %v", resp.GetStatus().Code, resp.GetStatus().Details)
 
 		}
+
+		if resp.GetValidatePeerCertificateChainResp().ValidationResult != s2av2pb.ValidatePeerCertificateChainResp_SUCCESS {
+			return fmt.Errorf("client cert verification failed: %v", resp.GetValidatePeerCertificateChainResp().ValidationDetails)
+		}
+
 		return nil
 	}
 }
@@ -88,21 +93,26 @@ func VerifyServerCertificateChain(hostname string, verificationMode s2av2pb.Vali
 				},
 			},
 		}); err != nil {
-			grpclog.Infof("Failed to send request to S2Av2 for client peer cert chain validation.")
+			grpclog.Infof("Failed to send request to S2Av2 for server peer cert chain validation.")
 			return err
 		}
 
 		// Get the response from S2Av2.
 		resp, err := cstream.Recv()
 		if err != nil {
-			grpclog.Infof("Failed to receive client peer cert chain validation response from S2Av2.")
+			grpclog.Infof("Failed to receive server peer cert chain validation response from S2Av2.")
 			return err
 		}
 
 		// Parse the response.
 		if (resp.GetStatus() != nil) && (resp.GetStatus().Code != uint32(codes.OK)) {
-			return fmt.Errorf("failed to offload client cert verification to S2A: %d, %v", resp.GetStatus().Code, resp.GetStatus().Details)
+			return fmt.Errorf("failed to offload server cert verification to S2A: %d, %v", resp.GetStatus().Code, resp.GetStatus().Details)
 		}
+
+		if resp.GetValidatePeerCertificateChainResp().ValidationResult != s2av2pb.ValidatePeerCertificateChainResp_SUCCESS {
+			return fmt.Errorf("server cert verification failed: %v", resp.GetValidatePeerCertificateChainResp().ValidationDetails)
+		}
+
 		return nil
 	}
 }

--- a/internal/v2/cert_verifier/cert_verifier_test.go
+++ b/internal/v2/cert_verifier/cert_verifier_test.go
@@ -92,7 +92,7 @@ func TestVerifyClientCertChain(t *testing.T) {
 		{
 			description: "empty chain",
 			rawCerts:    nil,
-			expectedErr: errors.New("failed to offload client cert verification to S2A: 3, client peer verification failed: client cert chain is empty"),
+			expectedErr: errors.New("client cert verification failed: client peer verification failed: client cert chain is empty"),
 		},
 		{
 			description: "chain of length 1",
@@ -176,7 +176,7 @@ func TestVerifyServerCertChain(t *testing.T) {
 			description: "empty chain",
 			hostname:    "host",
 			rawCerts:    nil,
-			expectedErr: errors.New("failed to offload client cert verification to S2A: 3, server peer verification failed: server cert chain is empty"),
+			expectedErr: errors.New("server cert verification failed: server peer verification failed: server cert chain is empty"),
 		},
 		{
 			description: "chain of length 1",

--- a/internal/v2/fakes2av2/fakes2av2.go
+++ b/internal/v2/fakes2av2/fakes2av2.go
@@ -290,7 +290,7 @@ func verifyClientPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.Se
 	derCertChain := req.GetClientPeer().CertificateChain
 	if len(derCertChain) == 0 {
 		s := "client peer verification failed: client cert chain is empty"
-		return buildValidatePeerCertificateChainSessionResp(uint32(codes.InvalidArgument), s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
+		return buildValidatePeerCertificateChainSessionResp(uint32(codes.OK), "", s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
 	}
 
 	// Obtain the set of root certificates.
@@ -332,7 +332,7 @@ func verifyServerPeer(req *s2av2pb.ValidatePeerCertificateChainReq) (*s2av2pb.Se
 	derCertChain := req.GetServerPeer().CertificateChain
 	if len(derCertChain) == 0 {
 		s := "server peer verification failed: server cert chain is empty"
-		return buildValidatePeerCertificateChainSessionResp(uint32(codes.InvalidArgument), s, s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
+		return buildValidatePeerCertificateChainSessionResp(uint32(codes.OK), "", s2av2pb.ValidatePeerCertificateChainResp_FAILURE, s, &s2av2ctx.S2AContext{}), nil
 	}
 
 	// Obtain the set of root certificates.

--- a/internal/v2/fakes2av2/fakes2av2_test.go
+++ b/internal/v2/fakes2av2/fakes2av2_test.go
@@ -282,8 +282,8 @@ func TestSetUpSession(t *testing.T) {
 			},
 			expectedResponse: &s2av2pb.SessionResp{
 				Status: &s2av2pb.Status{
-					Code:    uint32(codes.InvalidArgument),
-					Details: "client peer verification failed: client cert chain is empty",
+					Code:    uint32(codes.OK),
+					Details: "",
 				},
 				RespOneof: &s2av2pb.SessionResp_ValidatePeerCertificateChainResp{
 					ValidatePeerCertificateChainResp: &s2av2pb.ValidatePeerCertificateChainResp{


### PR DESCRIPTION
Add an if statement to check ValidationResult in the ValidatePeerCertificateChainResp SessionResp returned by S2Av2. 

The Fake S2Av2 Service layer was already populating and testing ValidationResult and ValidationDetails in fakes2av2.go and fakes2av2_test.go.

Also, fix some typos in VerifyServerCertificateChain error messages.