### PR TITLE
Add support for AppEngine-specific dialer.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,16 @@ go_repository(
   version = "v1.45.0",
 )
 
+# Google AppEngine.
+#
+# Last Updated: January 17, 2023.
+go_repository(
+  name = "org_golang_google_appengine",
+  importpath = "google.golang.org/appengine",
+  sum = "h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=",
+  version = "v1.4.0",
+)
+
 # Go Protobuf.
 #
 #

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.4.0
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=

--- a/internal/handshaker/service/BUILD
+++ b/internal/handshaker/service/BUILD
@@ -28,6 +28,8 @@ go_library(
     srcs = ["service.go"],
     importpath = "github.com/google/s2a-go/internal/handshaker/service",
     deps = [
+        "@org_golang_google_appengine//:go_default_library",
+        "@org_golang_google_appengine//socket:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/internal/handshaker/service/BUILD
+++ b/internal/handshaker/service/BUILD
@@ -31,6 +31,7 @@ go_library(
         "@org_golang_google_appengine//:go_default_library",
         "@org_golang_google_appengine//socket:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//grpclog:go_default_library",
     ],
 )
 

--- a/internal/handshaker/service/service.go
+++ b/internal/handshaker/service/service.go
@@ -43,7 +43,6 @@ var (
 	hsConnMap = make(map[string]*grpc.ClientConn)
 	// hsDialer will be reassigned in tests.
 	hsDialer = grpc.Dial
-
 )
 
 func init() {

--- a/internal/handshaker/service/service.go
+++ b/internal/handshaker/service/service.go
@@ -20,14 +20,22 @@
 package service
 
 import (
+	"context"
+	"net"
 	"sync"
+	"time"
 
-	_ "google.golang.org/appengine"
-	_ "google.golang.org/appengine/socket"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/socket"
 	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 )
 
 var (
+	// appEngineDialerHook is an AppEngine-specific dial option that is set
+	// during init time. If nil, then the application is not running on Google
+	// AppEngine.
+	appEngineDialerHook func(context.Context) grpc.DialOption
 	// mu guards hsConnMap and hsDialer.
 	mu sync.Mutex
 	// hsConnMap represents a mapping from an S2A handshaker service address
@@ -35,7 +43,19 @@ var (
 	hsConnMap = make(map[string]*grpc.ClientConn)
 	// hsDialer will be reassigned in tests.
 	hsDialer = grpc.Dial
+
 )
+
+func init() {
+	if !appengine.IsAppEngine() {
+		return
+	}
+	appEngineDialerHook = func(ctx context.Context) grpc.DialOption {
+		return grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return socket.DialTimeout(ctx, "tcp", addr, timeout)
+		})
+	}
+}
 
 // Dial dials the S2A handshaker service. If a connection has already been
 // established, this function returns it. Otherwise, a new connection is
@@ -48,8 +68,17 @@ func Dial(handshakerServiceAddress string) (*grpc.ClientConn, error) {
 	if !ok {
 		// Create a new connection to the S2A handshaker service. Note that
 		// this connection stays open until the application is closed.
+		grpcOpts := []grpc.DialOption{
+			grpc.WithInsecure(),
+		}
+		if appEngineDialerHook != nil {
+			if grpclog.V(1) {
+				grpclog.Info("Using AppEngine-specific dialer to talk to S2A.")
+			}
+			grpcOpts = append(grpcOpts, appEngineDialerHook(context.Background()))
+		}
 		var err error
-		hsConn, err = hsDialer(handshakerServiceAddress, grpc.WithInsecure())
+		hsConn, err = hsDialer(handshakerServiceAddress, grpcOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/handshaker/service/service.go
+++ b/internal/handshaker/service/service.go
@@ -22,6 +22,8 @@ package service
 import (
 	"sync"
 
+	_ "google.golang.org/appengine"
+	_ "google.golang.org/appengine/socket"
 	grpc "google.golang.org/grpc"
 )
 

--- a/internal/handshaker/service/service.go
+++ b/internal/handshaker/service/service.go
@@ -21,6 +21,7 @@ package service
 
 import (
 	"context"
+	"flag"
 	"net"
 	"sync"
 	"time"
@@ -36,6 +37,9 @@ var (
 	// during init time. If nil, then the application is not running on Google
 	// AppEngine.
 	appEngineDialerHook func(context.Context) grpc.DialOption
+	// enableAppEngineDialer indicates whether or not the AppEngine-specific
+	// dial option is used when the application is running on Google AppEngine.
+	enableAppEngineDialer bool
 	// mu guards hsConnMap and hsDialer.
 	mu sync.Mutex
 	// hsConnMap represents a mapping from an S2A handshaker service address
@@ -46,6 +50,8 @@ var (
 )
 
 func init() {
+	// TODO(matthewstevenson88): Remove flag and change default behavior.
+	flag.Bool("use_appengine_dialer", false, "Experimental: if true, the S2A-Go client uses an AppEngine-specific dialer when running on AppEngine.")
 	if !appengine.IsAppEngine() {
 		return
 	}
@@ -70,7 +76,7 @@ func Dial(handshakerServiceAddress string) (*grpc.ClientConn, error) {
 		grpcOpts := []grpc.DialOption{
 			grpc.WithInsecure(),
 		}
-		if appEngineDialerHook != nil {
+		if enableAppEngineDialer && appEngineDialerHook != nil {
 			if grpclog.V(1) {
 				grpclog.Info("Using AppEngine-specific dialer to talk to S2A.")
 			}


### PR DESCRIPTION
The default gRPC dialer does not seem to work on AppEngine. This will be e2e tested by deploying a Go app to AppEngine.