### PR TITLE
add an option to pass server name into s2a's tls config

### DIFF
--- a/internal/v2/s2av2_e2e_test.go
+++ b/internal/v2/s2av2_e2e_test.go
@@ -268,7 +268,7 @@ func TestNewClientTlsConfigWithTokenManager(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultE2ETimeout)
 	defer cancel()
-	config, err := NewClientTLSConfig(ctx, s2AAddr, accessTokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE)
+	config, err := NewClientTLSConfig(ctx, s2AAddr, accessTokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, "test")
 	if err != nil {
 		t.Errorf("NewClientTLSConfig() failed: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestNewClientTlsConfigWithoutTokenManager(t *testing.T) {
 	var tokenManager tokenmanager.AccessTokenManager
 	ctx, cancel := context.WithTimeout(context.Background(), defaultE2ETimeout)
 	defer cancel()
-	config, err := NewClientTLSConfig(ctx, s2AAddr, tokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE)
+	config, err := NewClientTLSConfig(ctx, s2AAddr, tokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, "test")
 	if err != nil {
 		t.Errorf("NewClientTLSConfig() failed: %v", err)
 	}

--- a/internal/v2/s2av2_e2e_test.go
+++ b/internal/v2/s2av2_e2e_test.go
@@ -268,7 +268,7 @@ func TestNewClientTlsConfigWithTokenManager(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultE2ETimeout)
 	defer cancel()
-	config, err := NewClientTLSConfig(ctx, s2AAddr, accessTokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, "test")
+	config, err := NewClientTLSConfig(ctx, s2AAddr, accessTokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, "test_server_name")
 	if err != nil {
 		t.Errorf("NewClientTLSConfig() failed: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestNewClientTlsConfigWithoutTokenManager(t *testing.T) {
 	var tokenManager tokenmanager.AccessTokenManager
 	ctx, cancel := context.WithTimeout(context.Background(), defaultE2ETimeout)
 	defer cancel()
-	config, err := NewClientTLSConfig(ctx, s2AAddr, tokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, "test")
+	config, err := NewClientTLSConfig(ctx, s2AAddr, tokenManager, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, "test_server_name")
 	if err != nil {
 		t.Errorf("NewClientTLSConfig() failed: %v", err)
 	}

--- a/s2a.go
+++ b/s2a.go
@@ -280,6 +280,10 @@ func (c *s2aTransportCreds) OverrideServerName(serverNameOverride string) error 
 
 // TLSClientConfigOptions specifies parameters for creating client TLS config.
 type TLSClientConfigOptions struct {
+	// ServerName is required by s2a as the expected name when verifying the hostname found in server's certificate.
+	// 		tlsConfig, _ := factory.Build(ctx, &s2a.TLSClientConfigOptions{
+	//			ServerName: "example.com",
+	//		})
 	ServerName string
 }
 

--- a/s2a.go
+++ b/s2a.go
@@ -279,7 +279,9 @@ func (c *s2aTransportCreds) OverrideServerName(serverNameOverride string) error 
 }
 
 // TLSClientConfigOptions specifies parameters for creating client TLS config.
-type TLSClientConfigOptions struct{}
+type TLSClientConfigOptions struct {
+	ServerName string
+}
 
 // TLSClientConfigFactory defines the interface for a client TLS config factory.
 type TLSClientConfigFactory interface {
@@ -321,7 +323,11 @@ type s2aTLSClientConfigFactory struct {
 
 func (f *s2aTLSClientConfigFactory) Build(
 	ctx context.Context, opts *TLSClientConfigOptions) (*tls.Config, error) {
-	return v2.NewClientTLSConfig(ctx, f.s2av2Address, f.tokenManager, f.verificationMode)
+	serverName := ""
+	if opts != nil && opts.ServerName != "" {
+		serverName = opts.ServerName
+	}
+	return v2.NewClientTLSConfig(ctx, f.s2av2Address, f.tokenManager, f.verificationMode, serverName)
 }
 
 func getVerificationMode(verificationMode VerificationModeType) s2av2pb.ValidatePeerCertificateChainReq_VerificationMode {


### PR DESCRIPTION

during handshake, s2a will check if the hostname found in server's certificate matches the expected server name. Currently s2a does not allow specifying this expected server name and using an empty string, which leads to error in handshake.

this PR makes it possible to specify such server name when building a client tls config instance.


bazel test ...
bazel build ...