### PR TITLE
fix: return tls as the security protocol

### DIFF
--- a/internal/v2/s2av2.go
+++ b/internal/v2/s2av2.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	s2aSecurityProtocol = "s2av2"
+	s2aSecurityProtocol = "tls"
 	defaultTimeout      = 20.0 * time.Second
 )
 

--- a/internal/v2/s2av2_test.go
+++ b/internal/v2/s2av2_test.go
@@ -121,7 +121,7 @@ func TestInfo(t *testing.T) {
 		t.Fatalf("NewClientCreds() failed: %v", err)
 	}
 	info := c.Info()
-	if got, want := info.SecurityProtocol, "s2av2"; got != want {
+	if got, want := info.SecurityProtocol, "tls"; got != want {
 		t.Errorf("info.SecurityProtocol=%v, want %v", got, want)
 	}
 }

--- a/s2a.go
+++ b/s2a.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	s2aSecurityProtocol = "s2a"
+	s2aSecurityProtocol = "tls"
 	// defaultTimeout specifies the default server handshake timeout.
 	defaultTimeout = 30.0 * time.Second
 )

--- a/s2a_test.go
+++ b/s2a_test.go
@@ -371,7 +371,7 @@ func TestInfo(t *testing.T) {
 	if got, want := info.ProtocolVersion, ""; got != want {
 		t.Errorf("info.ProtocolVersion=%v, want %v", got, want)
 	}
-	if got, want := info.SecurityProtocol, "s2a"; got != want {
+	if got, want := info.SecurityProtocol, "tls"; got != want {
 		t.Errorf("info.SecurityProtocol=%v, want %v", got, want)
 	}
 	if got, want := info.ServerName, ""; got != want {


### PR DESCRIPTION
grpc's underlying http2 client expects the security protocol to be 'tls', so it will talk https, otherwise default is http.