### PR TITLE
add EnableLegacyMode to s2a_options

### DIFF
--- a/s2a_options.go
+++ b/s2a_options.go
@@ -120,6 +120,8 @@ type ClientOptions struct {
 	//
 	// If true, enables the use of S2Av2.
 	EnableV2 bool
+	// If true, enable the use of legacy S2Av1.
+	EnableLegacyMode bool
 	// VerificationMode specifies the mode that S2A must use to verify the
 	// peer certificate chain.
 	VerificationMode VerificationModeType
@@ -171,6 +173,8 @@ type ServerOptions struct {
 	//
 	// If true, enables the use of S2Av2.
 	EnableV2 bool
+	// If true, enable the use of legacy S2Av1.
+	EnableLegacyMode bool
 	// VerificationMode specifies the mode that S2A must use to verify the
 	// peer certificate chain.
 	VerificationMode VerificationModeType

--- a/s2a_options.go
+++ b/s2a_options.go
@@ -120,7 +120,7 @@ type ClientOptions struct {
 	//
 	// If true, enables the use of S2Av2.
 	EnableV2 bool
-	// If true, enable the use of legacy S2Av1.
+	// If true, enables the use of legacy S2Av1.
 	EnableLegacyMode bool
 	// VerificationMode specifies the mode that S2A must use to verify the
 	// peer certificate chain.
@@ -173,7 +173,7 @@ type ServerOptions struct {
 	//
 	// If true, enables the use of S2Av2.
 	EnableV2 bool
-	// If true, enable the use of legacy S2Av1.
+	// If true, enables the use of legacy S2Av1.
 	EnableLegacyMode bool
 	// VerificationMode specifies the mode that S2A must use to verify the
 	// peer certificate chain.


### PR DESCRIPTION
this is step one to make v2 the default and deprecate the `EnableV2` flag