### PR TITLE
fix build target naming and visibility

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(
-    default_visibility = ["//:__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
 licenses(["notice"])
@@ -34,7 +34,7 @@ go_library(
     ],
     importpath = "github.com/google/s2a-go",
     deps = [
-        "//fallback:s2a_fallback",
+        "//fallback:fallback",
         "//internal/handshaker",
         "//internal/handshaker/service",
         "//internal/proto/common_go_proto",
@@ -46,6 +46,11 @@ go_library(
         "@org_golang_google_grpc//grpclog:go_default_library",
         "@org_golang_google_grpc//peer:go_default_library",
     ],
+)
+
+alias(
+    name = "s2a-go",
+    actual = ":s2a",
 )
 
 go_test(

--- a/BUILD
+++ b/BUILD
@@ -34,7 +34,7 @@ go_library(
     ],
     importpath = "github.com/google/s2a-go",
     deps = [
-        "//fallback:fallback",
+        "//fallback",
         "//internal/handshaker",
         "//internal/handshaker/service",
         "//internal/proto/common_go_proto",

--- a/fallback/BUILD
+++ b/fallback/BUILD
@@ -19,7 +19,7 @@ package(
 )
 
 go_library(
-    name = "s2a_fallback",
+    name = "fallback",
     srcs = ["s2a_fallback.go"],
     importpath = "github.com/google/s2a-go/fallback",
     deps = [
@@ -29,7 +29,7 @@ go_library(
 )
 
 go_test(
-    name = "s2a_fallback_test",
+    name = "fallback_test",
     srcs = ["s2a_fallback_test.go"],
-    embed = [":s2a_fallback"],
+    embed = [":fallback"],
 )

--- a/internal/v2/BUILD
+++ b/internal/v2/BUILD
@@ -26,7 +26,7 @@ go_library(
     ],
     importpath = "github.com/google/s2a-go/internal/v2",
     deps = [
-        "//fallback:s2a_fallback",
+        "//fallback:fallback",
         "//internal/handshaker/service",
         "//internal/proto/common_go_proto",
         "//internal/proto/v2/s2a_go_proto",

--- a/internal/v2/BUILD
+++ b/internal/v2/BUILD
@@ -26,7 +26,7 @@ go_library(
     ],
     importpath = "github.com/google/s2a-go/internal/v2",
     deps = [
-        "//fallback:fallback",
+        "//fallback",
         "//internal/handshaker/service",
         "//internal/proto/common_go_proto",
         "//internal/proto/v2/s2a_go_proto",


### PR DESCRIPTION
https://github.com/google/s2a-go/issues/99

When bazel auto-generates BUILD files for non-bazel module, e.g. google-api-go-client, for  the `deps` list, the conventions is to use the last section of an importPath as its target.  So for import `github.com/google/s2a-go`, the auto-generated build dependency is:  '@com_github_google_s2a_go//:s2a-go'.  However our actual go_library target is `s2a`, not `s2a-go`. This PR creates an alias to bridge this difference.

- Also fixed a similar issue for the fallback target.
- fix the s2a visiblity, make it public

