### PR TITLE
Add option to inject custom bidirectional stream to S2A.

### DIFF
--- a/s2a_options.go
+++ b/s2a_options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/s2a-go/fallback"
 
 	s2apb "github.com/google/s2a-go/internal/proto/common_go_proto"
+	s2av2pb "github.com/google/s2a-go/internal/proto/v2/s2a_go_proto"
 )
 
 // Identity is the interface for S2A identities.
@@ -78,6 +79,14 @@ const (
 	Spiffe
 )
 
+// s2AStream defines the operation for communicating with the S2A server over a bidirectional stream.
+type s2AStream interface {
+	// Send sends the message to the S2A server.
+	Send(*s2av2pb.SessionReq) error
+	// Recv receives the message from the S2A server.
+	Recv() (*s2av2pb.SessionResp, error)
+}
+
 // ClientOptions contains the client-side options used to establish a secure
 // channel using the S2A handshaker service.
 type ClientOptions struct {
@@ -125,6 +134,12 @@ type ClientOptions struct {
 
 	// Optional fallback after dialing with S2A fails.
 	FallbackOpts *FallbackOptions
+
+	// Generates an s2AStream interface for talking to the S2A server.
+	getS2AStream func() (*s2AStream, error)
+
+	// Serialized user specified policy for server authorization.
+	serverAuthorizationPolicy []byte
 }
 
 // FallbackOptions prescribes the fallback logic that should be taken if the application fails to connect with S2A.
@@ -170,6 +185,9 @@ type ServerOptions struct {
 	// VerificationMode specifies the mode that S2A must use to verify the
 	// peer certificate chain.
 	VerificationMode VerificationModeType
+
+	// Generates an s2AStream interface for talking to the S2A server.
+	getS2AStream func() (*s2AStream, error)
 }
 
 // DefaultServerOptions returns the default server options.


### PR DESCRIPTION
This is needed to allow user to configure the server authorization policy and the stream to talk to the S2A server.