### PR TITLE
Pass options that allow injection of custom stream to internal v2 code.

### DIFF
--- a/internal/v2/s2av2_e2e_test.go
+++ b/internal/v2/s2av2_e2e_test.go
@@ -115,7 +115,7 @@ func startFakeS2AOnUDS(t *testing.T, expToken string) string {
 // on.
 func startServer(t *testing.T, s2aAddress string, localIdentities []*commonpbv1.Identity) string {
 	// TODO(rmehta19): Pass verificationMode as a parameter to startServer.
-	creds, err := NewServerCreds(s2aAddress, localIdentities, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE)
+	creds, err := NewServerCreds(s2aAddress, localIdentities, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil)
 	if err != nil {
 		t.Errorf("NewServerCreds(%s) failed: %v", s2aAddress, err)
 	}
@@ -163,7 +163,7 @@ func startFallbackServer(t *testing.T) string {
 
 // runClient starts up a client and calls the server.
 func runClient(ctx context.Context, t *testing.T, clientS2AAddress, serverAddr string, localIdentity *commonpbv1.Identity, fallbackHandshake fallback.ClientHandshake) {
-	creds, err := NewClientCreds(clientS2AAddress, localIdentity, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, fallbackHandshake)
+	creds, err := NewClientCreds(clientS2AAddress, localIdentity, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, fallbackHandshake, nil, nil)
 	if err != nil {
 		t.Errorf("NewClientCreds(%s) failed: %v", clientS2AAddress, err)
 	}

--- a/internal/v2/s2av2_test.go
+++ b/internal/v2/s2av2_test.go
@@ -51,7 +51,7 @@ func TestNewClientCreds(t *testing.T) {
 				IdentityOneof: &commonpbv1.Identity_Hostname{
 					Hostname: "test_rsa_client_identity",
 				},
-			}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil)
+			}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("NewClientCreds() failed: %v", err)
 			}
@@ -83,7 +83,7 @@ func TestNewServerCreds(t *testing.T) {
 					},
 				},
 			}
-			c, err := NewServerCreds(fakes2av2Address, localIdentities, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE)
+			c, err := NewServerCreds(fakes2av2Address, localIdentities, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil)
 			if err != nil {
 				t.Fatalf("NewServerCreds() failed: %v", err)
 			}
@@ -118,7 +118,7 @@ func TestInfo(t *testing.T) {
 		IdentityOneof: &commonpbv1.Identity_Hostname{
 			Hostname: "test_rsa_client_identity",
 		},
-	}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil)
+	}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewClientCreds() failed: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestCloneClient(t *testing.T) {
 		IdentityOneof: &commonpbv1.Identity_Hostname{
 			Hostname: "test_rsa_client_identity",
 		},
-	}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, fallbackFunc)
+	}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, fallbackFunc, nil, nil)
 	if err != nil {
 		t.Fatalf("NewClientCreds() failed: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestCloneServer(t *testing.T) {
 			},
 		},
 	}
-	c, err := NewServerCreds(fakes2av2Address, localIdentities, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE)
+	c, err := NewServerCreds(fakes2av2Address, localIdentities, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil)
 	if err != nil {
 		t.Fatalf("NewServerCreds() failed: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestOverrideServerName(t *testing.T) {
 		IdentityOneof: &commonpbv1.Identity_Hostname{
 			Hostname: "test_rsa_client_identity",
 		},
-	}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil)
+	}, s2av2pb.ValidatePeerCertificateChainReq_CONNECT_TO_GOOGLE, nil, nil, nil)
 	s2av2Creds, ok := c.(*s2av2TransportCreds)
 	if !ok {
 		t.Fatal("The created creds is not of type s2av2TransportCreds")

--- a/s2a.go
+++ b/s2a.go
@@ -111,7 +111,7 @@ func NewClientCreds(opts *ClientOptions) (credentials.TransportCredentials, erro
 	if opts.FallbackOpts != nil && opts.FallbackOpts.FallbackClientHandshakeFunc != nil {
 		fallbackFunc = opts.FallbackOpts.FallbackClientHandshakeFunc
 	}
-	return v2.NewClientCreds(opts.S2AAddress, localIdentity, verificationMode, fallbackFunc)
+	return v2.NewClientCreds(opts.S2AAddress, localIdentity, verificationMode, fallbackFunc, opts.getS2AStream, opts.serverAuthorizationPolicy)
 }
 
 // NewServerCreds returns a server-side transport credentials object that uses
@@ -146,7 +146,7 @@ func NewServerCreds(opts *ServerOptions) (credentials.TransportCredentials, erro
 		}, nil
 	}
 	verificationMode := getVerificationMode(opts.VerificationMode)
-	return v2.NewServerCreds(opts.S2AAddress, localIdentities, verificationMode)
+	return v2.NewServerCreds(opts.S2AAddress, localIdentities, verificationMode, opts.getS2AStream)
 }
 
 // ClientHandshake initiates a client-side TLS handshake using the S2A.

--- a/s2a_options.go
+++ b/s2a_options.go
@@ -24,9 +24,9 @@ import (
 	"sync"
 
 	"github.com/google/s2a-go/fallback"
+	"github.com/google/s2a-go/stream"
 
 	s2apb "github.com/google/s2a-go/internal/proto/common_go_proto"
-	s2av2pb "github.com/google/s2a-go/internal/proto/v2/s2a_go_proto"
 )
 
 // Identity is the interface for S2A identities.
@@ -79,14 +79,6 @@ const (
 	Spiffe
 )
 
-// s2AStream defines the operation for communicating with the S2A server over a bidirectional stream.
-type s2AStream interface {
-	// Send sends the message to the S2A server.
-	Send(*s2av2pb.SessionReq) error
-	// Recv receives the message from the S2A server.
-	Recv() (*s2av2pb.SessionResp, error)
-}
-
 // ClientOptions contains the client-side options used to establish a secure
 // channel using the S2A handshaker service.
 type ClientOptions struct {
@@ -135,8 +127,8 @@ type ClientOptions struct {
 	// Optional fallback after dialing with S2A fails.
 	FallbackOpts *FallbackOptions
 
-	// Generates an s2AStream interface for talking to the S2A server.
-	getS2AStream func() (*s2AStream, error)
+	// Generates an S2AStream interface for talking to the S2A server.
+	getS2AStream func() (*stream.S2AStream, error)
 
 	// Serialized user specified policy for server authorization.
 	serverAuthorizationPolicy []byte
@@ -186,8 +178,8 @@ type ServerOptions struct {
 	// peer certificate chain.
 	VerificationMode VerificationModeType
 
-	// Generates an s2AStream interface for talking to the S2A server.
-	getS2AStream func() (*s2AStream, error)
+	// Generates an S2AStream interface for talking to the S2A server.
+	getS2AStream func() (*stream.S2AStream, error)
 }
 
 // DefaultServerOptions returns the default server options.

--- a/stream/s2a_stream.go
+++ b/stream/s2a_stream.go
@@ -1,0 +1,32 @@
+/*
+ *
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package stream provides an interface for bidirectional streaming to the S2A server.
+package stream
+
+import (
+	s2av2pb "github.com/google/s2a-go/internal/proto/v2/s2a_go_proto"
+)
+
+// S2AStream defines the operation for communicating with the S2A server over a bidirectional stream.
+type S2AStream interface {
+	// Send sends the message to the S2A server.
+	Send(*s2av2pb.SessionReq) error
+	// Recv receives the message from the S2A server.
+	Recv() (*s2av2pb.SessionResp, error)
+}


### PR DESCRIPTION
Moved the declaration of `S2AStream` into inner packages to avoid circular dependency.