### PR TITLE
retry if err when talking to s2a gRPC server

### DIFF
--- a/internal/v2/s2av2.go
+++ b/internal/v2/s2av2.go
@@ -134,8 +134,11 @@ func (c *s2av2TransportCreds) ClientHandshake(ctx context.Context, serverAuthori
 	defer cancel()
 	var err error
 	var s2AStream stream.S2AStream
-	retryer := retry.NewRetryer()
+	retryer := NewRetryer()
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
 		s2AStream, err = createStream(timeoutCtx, c.s2av2Address, c.getS2AStream)
 		if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
 			if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
@@ -169,8 +172,11 @@ func (c *s2av2TransportCreds) ClientHandshake(ctx context.Context, serverAuthori
 	if c.serverName != "" {
 		sn = c.serverName
 	}
-	retryer = retry.NewRetryer()
+	retryer = NewRetryer()
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
 		config, err = tlsconfigstore.GetTLSConfigurationForClient(sn, s2AStream, tokenManager, c.localIdentity, c.verificationMode, c.serverAuthorizationPolicy)
 		if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
 			if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
@@ -194,8 +200,11 @@ func (c *s2av2TransportCreds) ClientHandshake(ctx context.Context, serverAuthori
 	creds := credentials.NewTLS(config)
 	var conn net.Conn
 	var authInfo credentials.AuthInfo
-	retryer = retry.NewRetryer()
+	retryer = NewRetryer()
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
 		conn, authInfo, err = creds.ClientHandshake(ctx, serverName, rawConn)
 		if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
 			if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
@@ -227,8 +236,11 @@ func (c *s2av2TransportCreds) ServerHandshake(rawConn net.Conn) (net.Conn, crede
 
 	var err error
 	var s2AStream stream.S2AStream
-	retryer := retry.NewRetryer()
+	retryer := NewRetryer()
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
 		s2AStream, err = createStream(ctx, c.s2av2Address, c.getS2AStream)
 		if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
 			if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
@@ -255,8 +267,11 @@ func (c *s2av2TransportCreds) ServerHandshake(rawConn net.Conn) (net.Conn, crede
 	}
 
 	var config *tls.Config
-	retryer = retry.NewRetryer()
+	retryer = NewRetryer()
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
 		config, err = tlsconfigstore.GetTLSConfigurationForServer(s2AStream, tokenManager, c.localIdentities, c.verificationMode)
 		if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
 			if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
@@ -277,8 +292,11 @@ func (c *s2av2TransportCreds) ServerHandshake(rawConn net.Conn) (net.Conn, crede
 	var conn net.Conn
 	var authInfo credentials.AuthInfo
 	creds := credentials.NewTLS(config)
-	retryer = retry.NewRetryer()
+	retryer = NewRetryer()
 	for {
+		if err = ctx.Err(); err != nil {
+			break
+		}
 		conn, authInfo, err = creds.ServerHandshake(rawConn)
 		if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
 			if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
@@ -422,3 +440,5 @@ func GetS2ATimeout() time.Duration {
 	}
 	return timeout
 }
+
+var NewRetryer = func() *retry.S2ARetryer { return retry.NewRetryer() }

--- a/internal/v2/s2av2_e2e_test.go
+++ b/internal/v2/s2av2_e2e_test.go
@@ -197,8 +197,10 @@ func runClient(ctx context.Context, t *testing.T, clientS2AAddress, serverAddr s
 
 func TestEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	os.Setenv(accessTokenEnvVariable, "TestE2ETCP_token")
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 	// Start the fake S2As for the client and server.
@@ -304,8 +306,10 @@ func TestGRPCFallbackEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	// Set for testing only.
 	fallback.FallbackTLSConfigGRPC.InsecureSkipVerify = true
 	os.Setenv(accessTokenEnvVariable, "TestE2ETCP_token")
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 
@@ -358,8 +362,10 @@ func TestGRPCRetryAndFallbackEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	fallback.FallbackTLSConfigGRPC.InsecureSkipVerify = true
 	// Set an invalid token to trigger failures and retries when talking to S2A.
 	os.Setenv(accessTokenEnvVariable, "invalid_token")
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -81,6 +81,11 @@ type S2ARetryer struct {
 	attempts int
 }
 
+// Attempts return the number of retries attempted.
+func (r *S2ARetryer) Attempts() int {
+	return r.attempts
+}
+
 // Retry returns a boolean indicating whether retry should be performed
 // and the backoff duration.
 func (r *S2ARetryer) Retry(err error) (time.Duration, bool) {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package retry provides a retry helper for talking to S2A gRPC server.
+// The implementation is modeled after
+// https://github.com/googleapis/google-cloud-go/blob/main/compute/metadata/retry.go
+package retry
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+const (
+	maxRetryAttempts = 5
+)
+
+type defaultBackoff struct {
+	max time.Duration
+	mul float64
+	cur time.Duration
+}
+
+// Pause returns a duration, which is used as the backoff wait time
+// before the next retry.
+func (b *defaultBackoff) Pause() time.Duration {
+	d := time.Duration(1 + rand.Int63n(int64(b.cur)))
+	b.cur = time.Duration(float64(b.cur) * b.mul)
+	if b.cur > b.max {
+		b.cur = b.max
+	}
+	return d
+}
+
+// Sleep will wait for the specified duration or return on context
+// expiration.
+func Sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// NewRetryer creates an instance of S2ARetryer using the defaultBackoff
+// implementation.
+func NewRetryer() *S2ARetryer {
+	return &S2ARetryer{bo: &defaultBackoff{
+		cur: 100 * time.Millisecond,
+		max: 30 * time.Second,
+		mul: 2,
+	}}
+}
+
+type backoff interface {
+	Pause() time.Duration
+}
+
+// S2ARetryer implements a retry helper for talking to S2A gRPC server.
+type S2ARetryer struct {
+	bo       backoff
+	attempts int
+}
+
+// Retry returns a boolean indicating whether retry should be performed
+// and the backoff duration.
+func (r *S2ARetryer) Retry(err error) (time.Duration, bool) {
+	if err == nil {
+		return 0, false
+	}
+	if r.attempts >= maxRetryAttempts {
+		return 0, false
+	}
+	r.attempts++
+	return r.bo.Pause(), true
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -23,9 +23,10 @@ package retry
 
 import (
 	"context"
-	"google.golang.org/grpc/grpclog"
 	"math/rand"
 	"time"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 const (

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package retry
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+var testErr error = errors.New("test error")
+
+type constantBackoff struct{}
+
+func (b constantBackoff) Pause() time.Duration { return 100 }
+
+func TestS2ARetryer(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		wantDelay       time.Duration
+		wantShouldRetry bool
+	}{
+		{
+			name:            "retry on err",
+			err:             testErr,
+			wantDelay:       100,
+			wantShouldRetry: true,
+		},
+		{
+			name:            "don't retry if err is nil",
+			err:             nil,
+			wantDelay:       0,
+			wantShouldRetry: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			retryer := S2ARetryer{bo: constantBackoff{}}
+			delay, shouldRetry := retryer.Retry(tc.err)
+			if delay != tc.wantDelay {
+				t.Fatalf("retryer.Retry(%v) = %v, want %v", tc.err, delay, tc.wantDelay)
+			}
+			if shouldRetry != tc.wantShouldRetry {
+				t.Fatalf("retryer.Retry(%v) = %v, want %v", tc.err, shouldRetry, tc.wantShouldRetry)
+			}
+		})
+	}
+}
+
+func TestS2ARetryerAttempts(t *testing.T) {
+	retryer := S2ARetryer{bo: constantBackoff{}}
+	for i := 1; i <= 5; i++ {
+		_, shouldRetry := retryer.Retry(testErr)
+		if !shouldRetry {
+			t.Fatalf("retryer.Retry(testErr) = false, want true")
+		}
+	}
+	_, shouldRetry := retryer.Retry(testErr)
+	if shouldRetry {
+		t.Fatal("an error should only be retried 5 times")
+	}
+}
+
+func TestDefaultBackoff(t *testing.T) {
+	bo := defaultBackoff{
+		cur: 100 * time.Millisecond,
+		max: 30 * time.Second,
+		mul: 2,
+	}
+	pauseOne := bo.Pause()
+	pauseTwo := bo.Pause()
+	if pauseOne > 100*time.Millisecond {
+		t.Fatal("first backoff should be less than 100 milli seconds")
+	}
+	if pauseTwo > 2*100*time.Millisecond {
+		t.Fatal("second backoff should be less than 200 milli seconds")
+	}
+}

--- a/s2a.go
+++ b/s2a.go
@@ -393,22 +393,13 @@ func NewS2ADialTLSContextFunc(opts *ClientOptions) func(ctx context.Context, net
 		defer cancel()
 
 		var s2aTLSConfig *tls.Config
-		retryer := v2.NewRetryer()
-		for {
-			if err = ctx.Err(); err != nil {
-				break
-			}
-			s2aTLSConfig, err = factory.Build(timeoutCtx, &TLSClientConfigOptions{
-				ServerName: serverName,
+		retry.Run(timeoutCtx,
+			func() error {
+				s2aTLSConfig, err = factory.Build(timeoutCtx, &TLSClientConfigOptions{
+					ServerName: serverName,
+				})
+				return err
 			})
-			if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
-				if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
-					break
-				}
-				continue
-			}
-			break
-		}
 		if err != nil {
 			grpclog.Infof("error building S2A TLS config: %v", err)
 			return fallback(err)
@@ -417,21 +408,12 @@ func NewS2ADialTLSContextFunc(opts *ClientOptions) func(ctx context.Context, net
 		s2aDialer := &tls.Dialer{
 			Config: s2aTLSConfig,
 		}
-		retryer = v2.NewRetryer()
 		var c net.Conn
-		for {
-			if err = ctx.Err(); err != nil {
-				break
-			}
-			c, err = s2aDialer.DialContext(ctx, network, addr)
-			if backoff, shouldRetry := retryer.Retry(err); shouldRetry {
-				if sleepErr := retry.Sleep(ctx, backoff); sleepErr != nil {
-					break
-				}
-				continue
-			}
-			break
-		}
+		retry.Run(timeoutCtx,
+			func() error {
+				c, err = s2aDialer.DialContext(timeoutCtx, network, addr)
+				return err
+			})
 		if err != nil {
 			grpclog.Infof("error dialing with S2A to %s: %v", addr, err)
 			return fallback(err)

--- a/s2a_e2e_test.go
+++ b/s2a_e2e_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/google/s2a-go/fallback"
 	"github.com/google/s2a-go/internal/fakehandshaker/service"
-	"github.com/google/s2a-go/internal/v2"
 	"github.com/google/s2a-go/internal/v2/fakes2av2"
 	"github.com/google/s2a-go/retry"
 	"google.golang.org/grpc/credentials"
@@ -250,8 +249,10 @@ func TestV1EndToEndUsingFakeS2AOverTCP(t *testing.T) {
 
 func TestV2EndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	os.Setenv(accessTokenEnvVariable, testV2AccessToken)
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	v2.NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 	// Start the fake S2As for the client and server.
@@ -303,8 +304,10 @@ func TestV2GRPCFallbackEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	// Set for testing only.
 	fallback.FallbackTLSConfigGRPC.InsecureSkipVerify = true
 	os.Setenv(accessTokenEnvVariable, testV2AccessToken)
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	v2.NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 	// Start the fake S2A for the server.
@@ -343,8 +346,10 @@ func TestV2GRPCRetryAndFallbackEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	fallback.FallbackTLSConfigGRPC.InsecureSkipVerify = true
 	// Set an invalid token to trigger failures and retries when talking to S2A.
 	os.Setenv(accessTokenEnvVariable, "invalid_token")
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	v2.NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 	// Start the fake S2A for the server and client.
@@ -585,10 +590,13 @@ func runHTTPClient(t *testing.T, clientS2AAddress, serverAddr string, fallbackOp
 }
 func TestHTTPEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	os.Setenv(accessTokenEnvVariable, testV2AccessToken)
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	v2.NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
+
 	// Start the fake S2As for the client.
 	clientHandshakerAddr := startFakeS2A(t, false, testV2AccessToken)
 	t.Logf("fake handshaker for client running at address: %v", clientHandshakerAddr)
@@ -611,8 +619,10 @@ func TestHTTPEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 func TestHTTPFallbackEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	fallback.FallbackTLSConfigHTTP.InsecureSkipVerify = true
 	os.Setenv(accessTokenEnvVariable, testV2AccessToken)
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	v2.NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 
@@ -651,8 +661,10 @@ func TestHTTPRetryAndFallbackEndToEndUsingFakeS2AOverTCP(t *testing.T) {
 	fallback.FallbackTLSConfigHTTP.InsecureSkipVerify = true
 	// Set an invalid token to trigger failures and retries when talking to S2A.
 	os.Setenv(accessTokenEnvVariable, "invalid_token")
+	oldRetry := retry.NewRetryer
+	defer func() { retry.NewRetryer = oldRetry }()
 	testRetryer := retry.NewRetryer()
-	v2.NewRetryer = func() *retry.S2ARetryer {
+	retry.NewRetryer = func() *retry.S2ARetryer {
 		return testRetryer
 	}
 


### PR DESCRIPTION
add retry logic similar to the code used for talking to metadata server:
https://github.com/googleapis/google-cloud-go/blob/main/compute/metadata/retry.go

summary: err will be retried for up to 5 times: 
1st backoff:   random duration up to 0.1s
2nd backoff: random duration up to 0.2s
3rd backoff:  random duration up to 0.4s
4th backoff:  random duration up to 0.8s
5th backoff:  random duration up to 1.6s

tested running a test gae app and triggering the retry logic by:
case1: giving it a wrong s2a address
case2: setting a wrong server name in tls.config, so the handshake fails
and was able to observe (via log) 5 retries made for both cases.