### PR TITLE
update retry logic

### DIFF
--- a/internal/v2/s2av2.go
+++ b/internal/v2/s2av2.go
@@ -183,13 +183,7 @@ func (c *s2av2TransportCreds) ClientHandshake(ctx context.Context, serverAuthori
 	}
 
 	creds := credentials.NewTLS(config)
-	var conn net.Conn
-	var authInfo credentials.AuthInfo
-	retry.Run(timeoutCtx,
-		func() error {
-			conn, authInfo, err = creds.ClientHandshake(timeoutCtx, serverName, rawConn)
-			return err
-		})
+	conn, authInfo, err := creds.ClientHandshake(timeoutCtx, serverName, rawConn)
 	if err != nil {
 		grpclog.Infof("Failed to do client handshake using S2Av2: %v", err)
 		if c.fallbackClientHandshake != nil {
@@ -247,13 +241,7 @@ func (c *s2av2TransportCreds) ServerHandshake(rawConn net.Conn) (net.Conn, crede
 	}
 
 	creds := credentials.NewTLS(config)
-	var conn net.Conn
-	var authInfo credentials.AuthInfo
-	retry.Run(ctx,
-		func() error {
-			conn, authInfo, err = creds.ServerHandshake(rawConn)
-			return err
-		})
+	conn, authInfo, err := creds.ServerHandshake(rawConn)
 	if err != nil {
 		grpclog.Infof("Failed to do server handshake using S2Av2: %v", err)
 		return nil, nil, err

--- a/s2a.go
+++ b/s2a.go
@@ -396,24 +396,20 @@ func NewS2ADialTLSContextFunc(opts *ClientOptions) func(ctx context.Context, net
 		defer cancel()
 
 		var s2aTLSConfig *tls.Config
+		var c net.Conn
 		retry.Run(timeoutCtx,
 			func() error {
 				s2aTLSConfig, err = factory.Build(timeoutCtx, &TLSClientConfigOptions{
 					ServerName: serverName,
 				})
-				return err
-			})
-		if err != nil {
-			grpclog.Infof("error building S2A TLS config: %v", err)
-			return fallback(err)
-		}
+				if err != nil {
+					grpclog.Infof("error building S2A TLS config: %v", err)
+					return err
+				}
 
-		s2aDialer := &tls.Dialer{
-			Config: s2aTLSConfig,
-		}
-		var c net.Conn
-		retry.Run(timeoutCtx,
-			func() error {
+				s2aDialer := &tls.Dialer{
+					Config: s2aTLSConfig,
+				}
 				c, err = s2aDialer.DialContext(timeoutCtx, network, addr)
 				return err
 			})


### PR DESCRIPTION
- for HTTP, create a new tls config (new stream to S2A) for each DialContext retry
- for GRPC, remove the retry on calls to creds.ServerHandshake and creds.ClientHandshake. It makes more sense to let the current handshake fail, and rely on re-connect.