### PR TITLE
Remove break

### DIFF
--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -667,7 +667,6 @@ func (p *conn) handleHandshakeMessage() error {
 			}
 		case tlsHandshakeNewSessionTicketType:
 			// Do nothing for session ticket.
-			break
 		default:
 			return errors.New("unknown handshake message type")
 		}


### PR DESCRIPTION
break is not needed. When case is empty, we exit the switch without executing the default.