### PR TITLE
Fix defer in test

### DIFF
--- a/internal/handshaker/service/service_test.go
+++ b/internal/handshaker/service/service_test.go
@@ -43,7 +43,7 @@ func TestDial(t *testing.T) {
 		return func() {
 			hsDialer = temp
 		}
-	}()
+	}()()
 
 	ctx := context.Background()
 


### PR DESCRIPTION
The first () calls the function immediately, and the second calls the returned function at the end.

Doesn't really matter here because there's just one test, but happened to find this while writing a linter for this and figured I might as well send a PR.